### PR TITLE
fix js url match problem

### DIFF
--- a/spider.py
+++ b/spider.py
@@ -71,8 +71,9 @@ def getConstantAndHash():
     preUrl='http:'+page.select('.previous-comment-page')[0]['href']
     html=requests.get(preUrl,headers=headers).text
     
-    j=re.search(r'.*<script\ssrc=\"\/\/(cdn.jandan.net\/static\/min.*?)\"><\/script>.*',html)
-    jsFileUrl="http://"+j.group(1)
+    jsoup = BeautifulSoup(html, 'lxml')
+    j = jsoup.find('script', {'src':re.compile(r'\/\/cdn.jandan.net\/static\/min.*?')})
+    jsFileUrl = "http://" + j['src'][2:]
     jsFile=requests.get(jsFileUrl,headers=headers).text
 
     c=re.search(r'.*f_\w+\(e,\"(\w+)\".*',jsFile)


### PR DESCRIPTION
匹配js文件路径的正则表达式可能会匹配到html中的注释部分，进而解析出错误的js地址，此js在部分情况下是无效的
不用正则匹配，使用beautifulsoup的find()找到对应js位置，保证解析准确