### PR TITLE
全局的headers被意外修改后不可再用于获取页面

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.vscode/settings.json
+.vscode/tasks.json
+.vscode/launch.json
+.vscode/extensions.json

--- a/spider.py
+++ b/spider.py
@@ -144,7 +144,9 @@ L = threading.Lock()
 class Download(threading.Thread):  
     def __init__(self, urlMannager):  
         threading.Thread.__init__(self)  
-        self.urlMannager=urlMannager 
+        self.urlMannager=urlMannager
+        self.pic_headers = headers
+        self.pic_headers['Host'] = 'wx3.sinaimg.cn'
 
     def download_Img(self,url):
         isGif=re.match(r'(.*\.sinaimg\.cn\/)(\w+)(\/.+\.gif)',url)
@@ -157,8 +159,8 @@ class Download(threading.Thread):
         if not os.path.exists('img'):
             os.mkdir('img')
         with open ('img/'+str(len(os.listdir('./img')))+extensionName, 'wb') as f:
-            headers['Host']='wx3.sinaimg.cn'
-            f.write(requests.get(url,headers=headers).content)
+            # headers['Host']='wx3.sinaimg.cn'
+            f.write(requests.get(url,headers=self.pic_headers).content)
             f.close()
         L.release()
         


### PR DESCRIPTION
headers被放在全局用起来确实方便了不少，但是下载图片的Download类的实例需要改headers，这就导致之后Spider类的实例需要访问全局的headers是被修改后的且不能使用的(Host被改成用于图片获取的url了)。感觉整个结构是需要优化的，但是我也不知道怎么去做，只是简单地添加了一个Download的数据成员pic_headers，专门用于获取图片。